### PR TITLE
fix failing tests and remove negative zeros in formatNumber()

### DIFF
--- a/ACASLibraries.Web/acas/utility/utility.js
+++ b/ACASLibraries.Web/acas/utility/utility.js
@@ -204,19 +204,30 @@ acas.module('acas.utility', 'underscorejs', function () {
 				if (isNaN(value)) {
 					return null
 				}
-
+				
 				//handle percent - multiply by 100 before doing all the rounding and stuff
 				if (percent) {
 					value = value * 100
+				}
+
+				//anything smaller than this value is probably zero and is a floating point error
+				//in the past we've had issues with values very close to zero displaying as NaN.00
+				//this is a less-than-ideal way around that problem. 
+				if (Math.abs(value) < 1e-10) { 
+					value = 0
 				}
 
 				var negative = value < 0
 				if (negative) {
 					value = value * -1
 				}
-
-				//take value.toFixed in the next line to handle incredibly small values expressed in exponential notation
-				var rounded = +(Math.round(value.toFixed(20) + ("e+" + maxPrecision)) + ("e-" + maxPrecision))				
+				
+				var rounded = +(Math.round(value + ("e+" + maxPrecision)) + ("e-" + maxPrecision))
+				//if after rounding it's zero, we don't want the negative formatting
+				if (rounded === 0) {
+					negative = false
+				}				
+				
 				var stringValue = rounded.toString()
 				var decimalIndex = stringValue.indexOf('.')
 				var decimal = decimalIndex === -1 ? '' : stringValue.substr(decimalIndex + 1)
@@ -242,7 +253,7 @@ acas.module('acas.utility', 'underscorejs', function () {
 
 				//combine the pieces
 				var result = integer + (decimal !== '' ? '.' + decimal : '')
-
+				
 				//handle percent
 				if (percent) {
 					result = result + '%'

--- a/ACASLibraries.Web/acas/utility/utility.test.js
+++ b/ACASLibraries.Web/acas/utility/utility.test.js
@@ -197,8 +197,18 @@ describe('Formatting --> ', function () {
 
 		it('formatNumber() - tiny values', function () {
 			//there were some issues with numbers like these in the past
-			expect(formatting.formatNumber(-1.4551915228366852e-11)).toBe('(0.00)')
-			expect(formatting.formatNumber(21.4551915228366852e-11)).toBe('0.00')
+			expect(formatting.formatNumber(-1.4551915228366852e-11)).toBe('0.00')
+			expect(formatting.formatNumber(1.4551915228366852e-11)).toBe('0.00')
+			expect(formatting.formatNumber(-4.4551915228366852e-20)).toBe('0.00')
+			expect(formatting.formatNumber(4.4551915228366852e-20)).toBe('0.00')			
+			expect(formatting.formatNumber(-6.4551915228366852e-20)).toBe('0.00')			
+			expect(formatting.formatNumber(6.4551915228366852e-20)).toBe('0.00')
+			expect(formatting.formatNumber(-6.4551915228366852e-11)).toBe('0.00')
+			expect(formatting.formatNumber(6.4551915228366852e-11)).toBe('0.00')			
+		})
+
+		it('formatNumber() - huge values', function () {
+			//TODO - can formatNumber() support large exponentials?
 		})
 	});
 


### PR DESCRIPTION
Another, simpler and more reliable approach to tiny
numbers in formatNumber(). Additionally, no number
should display as (0.00). Most users would find that
confusing, just display. 0.00
