### PR TITLE
Ac typeahead

### DIFF
--- a/ACASLibraries.Web/acas/ui/typeahead/acTypeahead.Directive.js
+++ b/ACASLibraries.Web/acas/ui/typeahead/acTypeahead.Directive.js
@@ -1,32 +1,43 @@
-﻿'use strict';
+﻿'use strict'; 
 
 acas.module('acTypeahead', 'acas.ui.angular', 'underscorejs', function () {
-	acas.ui.angular.directive('acTypeahead', ['$timeout', '$window', '$compile', '$http', function ($timeout, $window, $compile, $http) {
+	acas.ui.angular.directive('acTypeahead', ['$timeout', '$window', '$compile', '$http', '$q', function ($timeout, $window, $compile, $http, $q) {
 		return {
 			restrict: 'E',
-			require: ['ngModel'],
 			scope: {				
 				ngModel: '=',
 				acTypeaheadOptions: '=', //see config object below for defaults
 				acReadonly: '=',
 				acDisplay: '=',
-				ngDisabled: '='				
+				ngDisabled: '=',
+				ngChange: '&',
 			},
 			replace: true,
 			link: function (scope, element) {
 				var config = _.extend({
-					idProperty: 'id',
+					idProperty: 'id', // if optionFormat is not used, both this and displayProperty are used
+					displayProperty: 'name', // if not passed in will be set to same as dataSearch if dataSearch is not a function
 					selectionFormat: 'name',
 					searchPath: '', //if searchPath is used, it will override data/dataSearch
 					data: null, //array of objects
 					dataSearch: 'name', //either function or name of property
-					optionFormat: function (item) { return item.name },
+					optionFormat: null, //if not passed in, template uses displayProperty of item in watch instead of bind
 					inputClass: 'form-control'
 				}, scope.acTypeaheadOptions)
 				scope.config = config //so that it can be accessed in the template
 
 				if (!scope.config.searchPath && !scope.config.data) {
-					throw 'ERROR: acTypeahead must use either searchPath or both data and dataSearch. Please see acas libraries code.'
+					// commenting for now - throws error when page loads before data
+					//throw 'ERROR: acTypeahead must use either searchPath or both data and dataSearch. Please see acas libraries code.'
+				}
+
+				if (scope.config.optionFormat && typeof (scope.config.optionFormat) !== 'function') {
+					scope.config.optionFormat = function(item) {return item[scope.config.optionFormat]}
+				}
+
+				// default displayProperty to be same as dataSearch if not explicitly set in options, if dataSearch is not function:
+				if (scope.config.displayProperty === 'name' && typeof (scope.config.dataSearch) !== 'function' && scope.config.dataSearch !== 'name') {
+					scope.config.displayProperty = scope.config.dataSearch
 				}
 
 				scope.showBox = false
@@ -44,15 +55,18 @@ acas.module('acTypeahead', 'acas.ui.angular', 'underscorejs', function () {
 							.success(function (data) {
 								deferred.resolve(data)
 							})
+	
 					} else {
 						var results
 						if (typeof (scope.config.dataSearch) === 'function') {
 							results = scope.config.dataSearch(scope.config.data, search)
 						} else { //should be a string
-							results = _.filter(scope.data, function (x) {
-								return x[scope.config.dataSearch].toString().toLowerCase().indexOf(search.toLowerCase()) !== -1
+							results = _.filter(scope.config.data, function (x) {
+							
+							return x[scope.config.dataSearch].toString().toLowerCase().indexOf(search.trim().toLowerCase()) !== -1
 							})
 						}
+
 						deferred.resolve(results)
 					}
 					return deferred.promise
@@ -98,10 +112,17 @@ acas.module('acTypeahead', 'acas.ui.angular', 'underscorejs', function () {
 						element.html('<span>{{display}}</>')
 					}
 					else {
-						var inputTemplate = '<input class="ac-typeahead {{config.inputClass}}" placeholder="Search..."  ng-model="display" ng-disabled="ngDisabled"/>'
+						var optionTemplateHtml
+						var inputTemplate = '<input class="ac-typeahead {{config.inputClass}}" placeholder="Search..."  ng-model="display" ng-change="ngChange" ng-disabled="ngDisabled"/>'
 						var dropdownTemplatePre = '<div ng-show="showBox" class="ac-typeahead-dropdown" tabindex="-1">'
-						var optionTemplateHtml = '<div class="ac-typeahead-dropdown-item" ng-class="{active: activeItem === $index}" ng-repeat="item in searchResults" ng-click="selectItem(item)" ng-bind-html="config.optionFormat(item)"></div>'
+						if (scope.config.optionFormat) {
+							optionTemplateHtml = '<div class="ac-typeahead-dropdown-item" ng-class="{active: activeItem === $index}" ng-repeat="item in searchResults" ng-click="selectItem(item)" ng-bind-html="config.optionFormat(item)"></div>'
+						}
+						else {
+							optionTemplateHtml = '<div class="ac-typeahead-dropdown-item" ng-class="{active: activeItem === $index}" ng-repeat="item in searchResults" ng-click="selectItem(item)" >{{item[config.displayProperty]}}</div>'
+						}
 						var noResultsTemplate = '<div class="ac-typeahead-dropdown-item no-results" ng-show="!searchResults.length">No Results Found</div>'
+								
 						var html = '<div class="ac-typeahead">' + inputTemplate + dropdownTemplatePre + optionTemplateHtml + noResultsTemplate + '</div></div>'
 						element.html(html)
 						input = element.children().children(":first")
@@ -117,30 +138,59 @@ acas.module('acTypeahead', 'acas.ui.angular', 'underscorejs', function () {
 						generateTemplate()
 					}					
 				)
-				
-				//watch the display - if it changes programmatically, update the value
-				scope.$watch(function () { return scope.acDisplay },
-					function () {
-						value = {
-							id: scope.ngModel,
-							name: scope.acDisplay
-						}
-						search()
-					}
-				)
 
-				//when the value changes, update both the display and the model
-				scope.$watch(function () { return value },
-					function () {
-						$timeout(function () {
-							scope.$apply(function () {
-								scope.ngModel = value.id,
-								scope.acDisplay = value.name,
-								scope.display = value.name
+
+				// For selecting an item, need completely separate execution path at watch definition for objects,
+				// otherwise other processes may nullify ngModel and the null non-object gets assigned an int.
+				// When ngmodel is an object the directive needs to treat both value and model as objects
+				// - allows two way binding and object changes can be handled with a watch in the controller
+				if (typeof (scope.ngModel) === 'object') {
+					scope.$watch(function () { return scope.acDisplay },
+						function () {
+							value = {}
+							search()
+						}
+					)
+					// when value changes and object is not empty, assign it to model
+					scope.$watch(function () { return value },
+						function () {
+							$timeout(function () {
+								if (Object.keys(value).length > 0) {
+									scope.$apply(function () {
+										scope.ngModel = value
+									})
+								}
 							})
-						})
-					}
-				)
+							
+						}
+					)
+				}
+				// otherwise handled the old way, where value is id/name pair and model is just the id
+				else {
+					//watch the display - if it changes programmatically, update the value
+					scope.$watch(function () { return scope.acDisplay },
+						function () {
+							value = {
+								id: scope.ngModel,
+								name: scope.acDisplay
+							}
+							search()
+						}
+					)
+
+					//when the value changes, update both the display and the model
+					scope.$watch(function () { return value },
+						function () {
+							$timeout(function () {
+								scope.$apply(function () {
+									scope.ngModel = value[scope.config.idProperty],
+									scope.acDisplay = value.name,
+									scope.display = value.name
+								})
+							})
+						}	
+					)
+				}
 
 				//when selecting an item, update value
 				scope.selectItem = function (item) {
@@ -148,7 +198,9 @@ acas.module('acTypeahead', 'acas.ui.angular', 'underscorejs', function () {
 						scope.$apply(function () {
 							value = item
 							scope.showBox = false
+							scope.searchResults = {}
 						})
+						
 					})
 				}
 

--- a/ACASLibraries.Web/acas/ui/typeahead/acTypeahead.Directive.js
+++ b/ACASLibraries.Web/acas/ui/typeahead/acTypeahead.Directive.js
@@ -27,8 +27,7 @@ acas.module('acTypeahead', 'acas.ui.angular', 'underscorejs', function () {
 				scope.config = config //so that it can be accessed in the template
 
 				if (!scope.config.searchPath && !scope.config.data) {
-					// commenting for now - throws error when page loads before data
-					//throw 'ERROR: acTypeahead must use either searchPath or both data and dataSearch. Please see acas libraries code.'
+					throw 'ERROR: acTypeahead must use either searchPath or both data and dataSearch. Please see acas libraries code.'
 				}
 
 				if (scope.config.optionFormat && typeof (scope.config.optionFormat) !== 'function') {


### PR DESCRIPTION
now can handle an object as ngmodel, and works without optionformat
